### PR TITLE
types, better error message and fix for numerial key in find

### DIFF
--- a/lib/Horde/Rdo/Base.php
+++ b/lib/Horde/Rdo/Base.php
@@ -128,7 +128,12 @@ abstract class Horde_Rdo_Base implements IteratorAggregate, ArrayAccess
             } elseif (!empty($this->{$rel['foreignKey']})) {
                 $this->_fields[$field] = $m->findOne($this->{$rel['foreignKey']});
                 if (empty($this->_fields[$field])) {
-                    throw new Horde_Rdo_Exception('The referenced object with key ' . $this->{$rel['foreignKey']} . ' does not exist. Your data is inconsistent');
+                    throw new Horde_Rdo_Exception(sprintf(
+                        'The referenced object of %s instance with key %s = %s does not exist. Your data is inconsistent',
+                        get_class($this),
+                        $rel['foreignKey'],
+                        $this->{$rel['foreignKey']},
+                    ));
                 }
             } else {
                 $this->_fields[$field] = null;

--- a/lib/Horde/Rdo/Base.php
+++ b/lib/Horde/Rdo/Base.php
@@ -189,7 +189,7 @@ abstract class Horde_Rdo_Base implements IteratorAggregate, ArrayAccess
      *
      * @see __set()
      */
-    public function offsetSet($field, $value)
+    public function offsetSet($field, $value): void
     {
         $this->__set($field, $value);
     }
@@ -215,7 +215,7 @@ abstract class Horde_Rdo_Base implements IteratorAggregate, ArrayAccess
      *
      * @see __isset()
      */
-    public function offsetExists($field)
+    public function offsetExists($field): bool
     {
         return $this->__isset($field);
     }
@@ -238,7 +238,7 @@ abstract class Horde_Rdo_Base implements IteratorAggregate, ArrayAccess
      *
      * @see __unset()
      */
-    public function offsetUnset($field)
+    public function offsetUnset($field): void
     {
         $this->__unset($field);
     }
@@ -261,7 +261,7 @@ abstract class Horde_Rdo_Base implements IteratorAggregate, ArrayAccess
      *
      * @return Horde_Rdo_Iterator The Iterator instance.
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new Horde_Rdo_Iterator($this);
     }

--- a/lib/Horde/Rdo/Iterator.php
+++ b/lib/Horde/Rdo/Iterator.php
@@ -58,7 +58,7 @@ class Horde_Rdo_Iterator implements Iterator {
     /**
      * Reset to the first key.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_valid = (false !== reset($this->_keys));
     }
@@ -87,7 +87,7 @@ class Horde_Rdo_Iterator implements Iterator {
     /**
      * Move to the next key in the iterator.
      */
-    public function next()
+    public function next(): void
     {
         $this->_valid = (false !== next($this->_keys));
     }
@@ -97,7 +97,7 @@ class Horde_Rdo_Iterator implements Iterator {
      *
      * @return boolean Inside array bounds?
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->_valid;
     }

--- a/lib/Horde/Rdo/List.php
+++ b/lib/Horde/Rdo/List.php
@@ -122,7 +122,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
     /**
      * Implementation of the rewind() method for iterator.
      */
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->_result) {
             unset($this->_result);
@@ -167,7 +167,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
      * @return Horde_Rdo_Base|null The next Rdo object in the set or
      * null if no more results.
      */
-    public function next()
+    public function next(): void
     {
         if (is_null($this->_result)) {
             $this->rewind();
@@ -190,7 +190,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
             }
         }
 
-        return $this->_current;
+        // return $this->_current;
     }
 
     /**
@@ -200,7 +200,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
      *
      * @return boolean  Whether or not an offset exists.
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $query = Horde_Rdo_Query::create($this->_query);
         $query->limit(1, $offset);
@@ -232,7 +232,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
      * 
      * @return Horde_Rdo_Base  An entity object at the offset position or null
      */
-    public function offsetSet($offset, $item)
+    public function offsetSet($offset, $item): void
     {
         throw new Horde_Rdo_Exception('You cannot add objects to a result set');
     }
@@ -247,7 +247,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
      *
      * @return Horde_Rdo_Base  An entity object at the offset position or null
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new Horde_Rdo_Exception('You cannot remove objects from a result set');
     }
@@ -257,7 +257,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
      *
      * @return boolean Whether the iteration is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         if (is_null($this->_result)) {
             $this->rewind();
@@ -270,7 +270,7 @@ class Horde_Rdo_List implements ArrayAccess, Iterator, Countable
      *
      * @return integer Number of elements in the list
      */
-    public function count()
+    public function count(): int
     {
         if (is_null($this->_count)) {
             $this->_count = $this->_mapper->count($this->_query);

--- a/lib/Horde/Rdo/Mapper.php
+++ b/lib/Horde/Rdo/Mapper.php
@@ -498,10 +498,7 @@ abstract class Horde_Rdo_Mapper implements Countable
                 // Numerically indexed arrays are assumed to be an array of
                 // primary keys.
                 $query = new Horde_Rdo_Query();
-                $query->combineWith('OR');
-                foreach ($argv[0] as $id) {
-                    $query->addTest($this->primaryKey, '=', $id);
-                }
+                $query->addTest($this->primaryKey, 'IN', $arg);
             } else {
                 $query = $arg;
             }

--- a/src/DefaultIterator.php
+++ b/src/DefaultIterator.php
@@ -60,7 +60,7 @@ class DefaultIterator implements Iterator {
     /**
      * Reset to the first key.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_valid = (false !== reset($this->_keys));
     }
@@ -89,7 +89,7 @@ class DefaultIterator implements Iterator {
     /**
      * Move to the next key in the iterator.
      */
-    public function next()
+    public function next(): void
     {
         $this->_valid = (false !== next($this->_keys));
     }
@@ -99,7 +99,7 @@ class DefaultIterator implements Iterator {
      *
      * @return boolean Inside array bounds?
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->_valid;
     }

--- a/src/DefaultList.php
+++ b/src/DefaultList.php
@@ -123,7 +123,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
     /**
      * Implementation of the rewind() method for iterator.
      */
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->_result) {
             unset($this->_result);
@@ -168,7 +168,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
      * @return Base|null The next Rdo object in the set or
      * null if no more results.
      */
-    public function next()
+    public function next(): void
     {
         if (is_null($this->_result)) {
             $this->rewind();
@@ -191,7 +191,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
             }
         }
 
-        return $this->_current;
+        // return $this->_current;
     }
 
     /**
@@ -201,7 +201,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
      *
      * @return boolean  Whether or not an offset exists.
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $query = BaseQuery::create($this->_query);
         $query->limit(1, $offset);
@@ -233,7 +233,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
      * 
      * @return Base  An entity object at the offset position or null
      */
-    public function offsetSet($offset, $item)
+    public function offsetSet($offset, $item): void
     {
         throw new RdoException('You cannot add objects to a result set');
     }
@@ -248,7 +248,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
      *
      * @return Base  An entity object at the offset position or null
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new RdoException('You cannot remove objects from a result set');
     }
@@ -258,7 +258,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
      *
      * @return boolean Whether the iteration is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         if (is_null($this->_result)) {
             $this->rewind();
@@ -271,7 +271,7 @@ class DefaultList implements ArrayAccess, Iterator, Countable, RampageList
      *
      * @return integer Number of elements in the list
      */
-    public function count()
+    public function count(): int
     {
         if (is_null($this->_count)) {
             $this->_count = $this->_mapper->count($this->_query);

--- a/src/RampageObject.php
+++ b/src/RampageObject.php
@@ -410,7 +410,7 @@ class RampageObject implements Rampage
      *
      * @param string $relationship  The relationship key in the mapper
      * @param Rampage $peer  The object to remove from the relation
-     * @return integer  The number of relations affected
+     * @return int  The number of relations affected
      * @throws RdoException
      */
     public function removeRelation(string $relationship, Rampage $peer = null): int

--- a/src/RampageObject.php
+++ b/src/RampageObject.php
@@ -413,7 +413,7 @@ class RampageObject implements Rampage
      * @return integer  The number of relations affected
      * @throws RdoException
      */
-    public function removeRelation(string $relationship, Rampage $peer = null): integer
+    public function removeRelation(string $relationship, Rampage $peer = null): int
     {
         return $this->mapper->removeRelation($relationship, $this, $peer);
     }


### PR DESCRIPTION
- add correct types to some classes, so they match the interfaces they implement
- better error message for missing referenced object in `lib/Horde/Rdo/Base.php`
- fix Mapper::find with numerically indexed arrays